### PR TITLE
Convert version to fixed string, add soft-clearing function

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For most use cases, this matrix will be all you need:
 
 > Only call these functions upon a user action, such as when the user clicks a button. **Do not use MXUPS functions programmatically.**
 
-> MXUPS automatically excludes keys with the `_` prefix (such as `_id`). Use the `_` prefix to store data that is not meant to be exported.
+> Most MXUPS functions automatically exclude "reserved keys". This includes all keys with the `_` prefix, along with `ally-supports-cache`.
 
 ## API Examples
 
@@ -155,7 +155,8 @@ It is strongly recommended that you pass a custom error fallback function to `im
 
 MXUPS internally uses a neat set of helper utilities. These can be imported manually and used to create your own custom logic:
 
-- `clearAllStorage()` erases everything in local storage.
+- `clearStorage()` erases local storage.
+- `clearAllStorage()` completely erases local storage, including reserved keys.
 - `createPackage()` converts local storage into a JSON package.
 - `writeObject()` clears local storage and writes the given storage package to local storage.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hikium/mxups",
-  "version": "1.0.0-alpha.2",
+  "version": "1.0.0-alpha.3",
   "description": "Utilities for importing and exporting local storage",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,8 @@ export { exportFS } from "./exportFS";
 export { importFS } from "./importFS";
 
 // Utilities
-export { clearAllStorage } from "./utils/clearAllStorage";
+export { clearStorage } from "./utils/clearStorage";
+export { clearAllStorage } from "./utils/clearStorage";
 export { createPackage } from "./utils/createPackage";
 export { writeObject } from "./utils/writeObject";
 export { version } from "./utils/version";

--- a/src/utils/clearAllStorage.ts
+++ b/src/utils/clearAllStorage.ts
@@ -1,7 +1,0 @@
-/**
- * Runs `localStorage.clear()` and **completely erases everything** in local storage.
- */
-export const clearAllStorage = () => {
-  localStorage.clear();
-  console.log("MXUPS: Cleared all local storage.");
-};

--- a/src/utils/clearStorage.ts
+++ b/src/utils/clearStorage.ts
@@ -1,0 +1,36 @@
+/**
+ * Runs `localStorage.clear()` and **erases everything** in local storage, except for reserved keys.
+ */
+export const clearStorage = () => {
+  // Collect all keys in local storage
+  const storage = typeof window !== "undefined" ? localStorage : "";
+
+  // Filter out keys with the prefix "_"
+  // These are reserved for internal use
+  const filteredStorage = {};
+  Object.keys(storage).forEach((key) => {
+    if (key.substring(0, 1) !== "_") {
+      // Filter out "ally-supports-cache"
+      if (key !== "ally-supports-cache") {
+        // @ts-ignore: Will be fixed at a later date
+        filteredStorage[key] = storage[key];
+      }
+    }
+  });
+
+  // Clear filtered storage
+  Object.keys(filteredStorage).forEach((key) => {
+    // @ts-ignore: Will be fixed at a later date
+    localStorage.removeItem(key);
+  });
+
+  console.log("MXUPS: Cleared local storage, excluding reserved keys.");
+};
+
+/**
+ * Runs `localStorage.clear()` and **completely erases everything** in local storage.
+ */
+export const clearAllStorage = () => {
+  localStorage.clear();
+  console.log("MXUPS: Cleared all local storage.");
+};

--- a/src/utils/createPackage.ts
+++ b/src/utils/createPackage.ts
@@ -10,8 +10,11 @@ export const createPackage = () => {
   const filteredStorage = {};
   Object.keys(storage).forEach((key) => {
     if (key.substring(0, 1) !== "_") {
-      // @ts-ignore: Will be fixed at a later date
-      filteredStorage[key] = storage[key];
+      // Filter out "ally-supports-cache"
+      if (key !== "ally-supports-cache") {
+        // @ts-ignore: Will be fixed at a later date
+        filteredStorage[key] = storage[key];
+      }
     }
   });
 

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -2,9 +2,8 @@
  * Returns the MXUPS package version and logs it to the browser console.
  */
 export const version = (): string => {
-  // Get the version from package.json
-  const packageManifest = require("../../package.json");
-  const versionInPackageManifest = packageManifest.version;
+  // In the future, a mechanism will be added to collect the version from package.json
+  const versionInPackageManifest = "1.0.0-alpha.3";
 
   // Log the version
   console.debug(

--- a/src/utils/writeObject.ts
+++ b/src/utils/writeObject.ts
@@ -1,20 +1,25 @@
-import { clearAllStorage } from "./clearAllStorage";
+import { clearStorage } from "./clearStorage";
 
 /**
  * **Overwrites** storage and then applies the given object.
  *
- * This automatically excludes all keys with the "_" prefix. Applications can use this to store instance-specific data.
+ * This automatically excludes keys with the "_" prefix and "ally-supports-cache". Applications can "_" keys to store device-specific data.
  *
  * @param {Object} storage The object containing the keys and values to be applied to storage.
  */
 export const writeObject = (storage: { [x: string]: string }) => {
-  clearAllStorage();
+  // Clear storage except for reserved keys
+  clearStorage();
+
   // For each key, set the value
   // However, do not set the values of keys with the prefix "_"
   // These are reserved for internal use
   Object.keys(storage).forEach((key) => {
     if (key.substring(0, 1) !== "_") {
-      localStorage.setItem(key, storage[key]);
+      // Exclude "ally-supports-cache"
+      if (key !== "ally-supports-cache") {
+        localStorage.setItem(key, storage[key]);
+      }
     }
   });
 };


### PR DESCRIPTION
The `1.0.0-alpha.3` update is small but important. It resolves a major bug generated because of the new distribution model, converting `version()` to a fixed version string, no longer connected to the package manifest. Also, a new "soft-clear" function, `clearStorage()`, allows for local storage to be cleared excluding reserved keys. The original "full-clear" `clearAllStorage()` remains and this change is not breaking.